### PR TITLE
Use port 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Agente virtual de Creai para gestionar solicitudes de viaje de negocio en Slack 
    FIREBASE_DATABASE_URL=<url_firebase>
 
    # Opcional: puerto para el servidor (desarrollo local)
-   PORT=3000  # Cloud Run establece esta variable automáticamente
+   PORT=8080  # Cloud Run establece esta variable automáticamente
    4. Compila TypeScript:
       npm run build
    
@@ -62,7 +62,7 @@ npm run dev
 1. Asegúrate de tener las variables de entorno configuradas.
 2. Ejecuta:
       npm start
-   3. El servidor escuchará en el puerto configurado (por defecto 9000).
+   3. El servidor escuchará en el puerto configurado (por defecto 8080).
 
 ## Uso
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
       - '--image=gcr.io/$PROJECT_ID/virtual-agent:$SHORT_SHA'
       - '--region=us-central1'
       - '--platform=managed'
-      - '--port=3000'
+      - '--port=8080'
       - '--quiet'
 images:
   - 'gcr.io/$PROJECT_ID/virtual-agent:$SHORT_SHA'

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -26,19 +26,8 @@ export function setupSlack(agent: TravelAgent) {
 
   // Start the Slack listener on the port expected by the environment
   (async () => {
-
-    const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+    const port = process.env.PORT ? Number(process.env.PORT) : 8080;
     await app.start(port);
     console.log(`Slack app is running on port ${port}!`);
-
-
-    const port = process.env.PORT ? Number(process.env.PORT) : 3000;
-    await app.start(port);
-    console.log(`Slack app is running on port ${port}!`);
-
-    await app.start()
-    console.log('Slack app is running!')
-
-
   })();
 }


### PR DESCRIPTION
## Summary
- deploy Cloud Run on port 8080
- note the development port in README
- default Slack server to port 8080
- clean up duplicated start logic

## Testing
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6884827939008325b7603fc2e5998f32