### PR TITLE
Fix system instruction in startChat

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -108,7 +108,7 @@ export default class TravelAgent {
   private createChat(): ChatSession {
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!)
     const model = genAI.getGenerativeModel({ model: 'gemini-pro' })
-    return model.startChat({ history: [{ role: 'system', parts: [{ text: SYSTEM_PROMPT }] }] })
+    return model.startChat({ systemInstruction: SYSTEM_PROMPT })
   }
 
   async handleMessage(userId: string, text: string): Promise<string> {


### PR DESCRIPTION
## Summary
- fix TravelAgent initialization with Google GenAI library to pass system prompt as `systemInstruction`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68852c3962008325bbfaf24596eb4bf1