### PR TITLE
Fix Gemini default model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Google Gemini
 GEMINI_API_KEY=
-GEMINI_MODEL=gemini-2.0-pro
+GEMINI_MODEL=gemini-pro
 
 # Slack
 SLACK_BOT_TOKEN=

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Agente virtual de Creai para gestionar solicitudes de viaje de negocio en Slack 
    # Proveedor de LLM Google Gemini
    GEMINI_API_KEY=<tu_gemini_api_key>
    # Opcional: modelo de Gemini a utilizar
-   GEMINI_MODEL=gemini-2.0-pro
+   GEMINI_MODEL=gemini-pro
 
    # Slack
    SLACK_BOT_TOKEN=<xoxb-...>

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -107,7 +107,7 @@ export default class TravelAgent {
 
   private createChat(): Chat {
     const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY! })
-    const modelName = process.env.GEMINI_MODEL || 'gemini-2.0-pro'
+    const modelName = process.env.GEMINI_MODEL || 'gemini-pro'
     return ai.chats.create({
       model: modelName,
       config: { systemInstruction: SYSTEM_PROMPT },


### PR DESCRIPTION
## Summary
- use `gemini-pro` as default model when env variable not set
- update docs and .env example to match

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688534b910b08325a3efcd1fdc83ea7e