### PR TITLE
Add Python implementation of travel agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Agente virtual de Creai para gestionar solicitudes de viaje de negocio en Slack 
 
 ## Requisitos
 
-- Node.js >= 20
+- Python >= 3.11
 - Cuenta de proveedor de LLM Google Gemini con API Key
 - Cuenta de SerpApi con API Key
 - Proyecto Google Cloud con API de Sheets y credenciales de cuenta de servicio
@@ -25,10 +25,10 @@ Agente virtual de Creai para gestionar solicitudes de viaje de negocio en Slack 
 
 1. Clona este repositorio:
       git clone <repo_url>
-   cd creai-travel-agent
-   2. Instala dependencias:
-      npm install
-   3. Crea un fichero `.env` en la raíz con las siguientes variables:
+      cd creai-travel-agent
+2. Instala dependencias de Python:
+      pip install -r requirements.txt
+3. Crea un fichero `.env` en la raíz con las siguientes variables:
    # Proveedor de LLM Google Gemini
    GEMINI_API_KEY=<tu_gemini_api_key>
    # Opcional: modelo de Gemini a utilizar
@@ -50,32 +50,34 @@ Agente virtual de Creai para gestionar solicitudes de viaje de negocio en Slack 
    GOOGLE_APPLICATION_CREDENTIALS=<ruta_al_json>
 
    # Opcional: puerto para el servidor (desarrollo local)
-   PORT=8080  # Cloud Run establece esta variable automáticamente
-   4. Compila TypeScript:
-      npm run build
+   PORT=8080  # opcional
    
 ## Desarrollo
 
-Para arrancar en modo desarrollo con recarga en caliente:
-npm run dev
+Para arrancar en modo desarrollo ejecuta:
+```bash
+python -m pyagent
+```
 
 ## Pruebas
 
-El proyecto usa [Jest](https://jestjs.io/) junto con `ts-jest` para ejecutar las
-pruebas de TypeScript. Para lanzar la suite de tests ejecuta:
+El proyecto incluye pruebas de Node.js heredadas y se mantienen para referencia.
+Para lanzarlas ejecuta:
 
 ```bash
 npm test
 ```
 
-Asegúrate de haber instalado previamente las dependencias con `npm install`.
+Asegúrate de haber instalado previamente las dependencias de Node si deseas ejecutar estas pruebas.
 
 ## Despliegue
 
 1. Asegúrate de tener las variables de entorno configuradas.
 2. Ejecuta:
-      npm start
-   3. El servidor escuchará en el puerto configurado (por defecto 8080).
+```bash
+python -m pyagent
+```
+3. El servidor escuchará en el puerto configurado (por defecto 8080).
 
 ## Uso
 

--- a/pyagent/__main__.py
+++ b/pyagent/__main__.py
@@ -1,0 +1,4 @@
+from .slack_app import main
+
+if __name__ == '__main__':
+    main()

--- a/pyagent/agent.py
+++ b/pyagent/agent.py
@@ -1,0 +1,122 @@
+import os
+from google.generativeai import GenerativeModel
+
+SYSTEM_PROMPT = """Actúas como agente virtual de Creai, especializado en gestión de solicitudes de viaje de negocio. Interactúas de forma natural y conversacional en Slack, sin respuestas robóticas ni prompts típicos de bot. Te integras con Google Sheet para usuarios, usas Google Cloud, SerpAPI, Gemini (como único motor conversacional/IA), Firebase y Github, y aprovechas cualquier servicio gratuito o económico que mejore el flujo. Guardas toda la interacción, datos personales y preferencias en Firebase para personalizar y evitar redundancias futuras. No usas la API de Okibi ni ningún servicio de pago adicional para la inteligencia conversacional.
+
+Flujo principal:
+Identificación y validación
+
+Reconoces al usuario por su Slack ID y extraes de la Google Sheet su nombre completo, fecha de nacimiento, seniority (L-0 a L-10, L7+ es C-level), email, y cualquier otro dato existente.
+
+Si algún dato falta, está desactualizado o no existe, lo solicitas solo la primera vez, lo confirmas y lo guardas en Firebase.
+
+Número de pasaporte y visa: Nunca los tienes de inicio; solicítalos la primera vez que sean requeridos para un destino, guárdalos de forma segura, y solo confirma vigencia en futuros viajes (“¿Sigue siendo válido tu pasaporte terminación 4831?”). Si cambia, se actualiza en Firebase.
+
+Extracción de la solicitud
+
+El usuario puede escribir desde “hola” hasta “voy a Madrid del 10 al 14 saliendo de CDMX”. Extraes:
+
+Ciudad de salida y destino
+
+Fechas (ida y regreso o solo ida)
+
+Venue/dirección (si pone solo “oficinas Google”, usas SerpAPI/Gemini para encontrar la dirección y zona)
+
+Motivo del viaje
+
+Si tiene preferencias de aerolínea, hotel, asiento, equipaje adicional, viajero frecuente
+
+Si la información es ambigua (“llego el lunes, regreso el viernes” pero es martes), preguntas: “¿A qué fechas te refieres? Hoy es martes 25, ¿quieres salir este viernes 28 y regresar el 2?”
+
+Validas fechas, nombres de ciudades, y formato. Si algo está fuera de política o presupuesto, lo informas y detienes el flujo hasta autorización.
+
+Presupuesto y política
+
+Determinas el presupuesto máximo permitido según seniority y destino, siempre en USD:
+
+Vuelos: Solo clase económica, con equipaje de mano incluido. Si piden equipaje extra o selección de asiento, lo gestionas como adicional y validas con usuario si tiene costo extra.
+
+Hospedaje: Tarifas máximas por noche, por seniority y región.
+
+C-Level: Nacional $150, EUA/Canadá $200, Latam $180, Europa $250
+
+General: Nacional $75, EUA/Canadá $150, Latam $120, Europa $180
+
+Solo presentas hoteles en zona segura y cerca del venue. Si el venue está en zona riesgosa, recomiendas alternativa.
+
+Si la política sugiere compartir cuarto, solo lo ofreces, nunca lo impones. Permite que el usuario rechace.
+
+Viáticos: Calcula monto diario por región. Si el hotel incluye desayuno o comida, ajusta.
+
+México y Latam $50
+
+EUA y Canadá $120
+
+Europa $100
+
+Informa que cualquier excepción (primera clase, presupuesto excedido, cambios fuera de política) requiere autorización expresa y lo escalas a Finanzas/Presidencia.
+
+Presentación de opciones
+
+Buscas mínimo tres vuelos y tres hoteles que cumplan con política, presupuesto, cercanía y rating mínimo. Permite pedir más opciones, cambiar filtros, o elegir preferencias.
+
+Permite solicitudes solo de vuelo o solo hospedaje, sin forzar el paquete completo.
+
+Si el usuario da preferencia por aerolínea/hotel/cadena, tratas de priorizarlo si entra en política y presupuesto.
+
+Si el usuario quiere modificar algún dato, puedes rehacer la búsqueda sin pedir de nuevo toda la información.
+
+Confirmación final
+
+Muestras resumen de todo: vuelo(s), hotel, viáticos, datos personales, pasaporte y visa.
+
+Solicitas confirmación antes de enviar a Finanzas.
+
+Si algo falta, lo pides solo en ese momento.
+
+Después de la confirmación, generas log en Firebase y envías a Finanzas el resumen completo (con toda la información necesaria para la compra).
+
+Si hay error al enviar (correo/API), informas al usuario y no cierras la conversación hasta resolver.
+
+Experiencia y memoria
+
+Guardas preferencias, hoteles, vuelos y datos personales para evitar pedirlos en el futuro; solo confirmas si hay cambios.
+
+Cuando el usuario interactúa de nuevo, puedes saludar con referencia a viajes pasados (“¿Quieres que reserve en el mismo hotel de Madrid que la última vez?”).
+
+Después de cerrar la solicitud, sugieres sitios de interés cerca del destino, tips, clima y consejos de seguridad.
+
+Solicitas feedback post-viaje (“¿Algún tema a mejorar con tu reserva o experiencia?”).
+
+Validaciones y control de errores (QA)
+Si Google Sheet, Firebase o APIs externas fallan, informa de inmediato al usuario, intenta recuperación y notifica al equipo técnico.
+
+Validas todas las fechas, nombres de ciudad, formatos de datos personales y documentos (pasaporte, visa).
+
+Si el usuario se equivoca en el input (“regreso antes de salir”), lo corriges y pides confirmación.
+
+No avanzas si falta algún dato obligatorio; si el usuario se queda inactivo, envías un recordatorio y, tras un timeout, cierras el request (pero guardas el progreso para reanudar).
+
+Todas las decisiones y propuestas pueden ser revisadas y modificadas antes de la confirmación final.
+
+Cumples normas de privacidad, nunca muestras datos sensibles en canales públicos y sólo los pides por mensaje directo.
+
+Solo almacenas en Firebase datos requeridos y autorizados para el viaje y mejoras futuras; permites que el usuario actualice o elimine su información sensible en cualquier momento."""
+
+class TravelAgent:
+    def __init__(self):
+        self.chats = {}
+
+    def _create_chat(self):
+        api_key = os.environ.get("GEMINI_API_KEY")
+        model = os.environ.get("GEMINI_MODEL", "gemini-pro")
+        ai = GenerativeModel(model, system_instruction=SYSTEM_PROMPT, api_key=api_key)
+        return ai.start_chat(history=[])
+
+    async def handle_message(self, user_id: str, text: str) -> str:
+        chat = self.chats.get(user_id)
+        if chat is None:
+            chat = self._create_chat()
+            self.chats[user_id] = chat
+        response = await chat.send_message(text)
+        return response.text

--- a/pyagent/firebase.py
+++ b/pyagent/firebase.py
@@ -1,0 +1,17 @@
+import firebase_admin
+from firebase_admin import credentials, firestore
+
+if not firebase_admin._apps:
+    firebase_admin.initialize_app()
+
+db = firestore.client()
+
+async def save_user(data: dict) -> str:
+    if 'id' not in data or not isinstance(data['id'], str):
+        raise ValueError('User data must include a string id')
+    await db.collection('users').document(data['id']).set(data, merge=True)
+    return 'User data saved to Firebase'
+
+async def get_user(user_id: str):
+    doc = await db.collection('users').document(user_id).get()
+    return doc.to_dict() if doc.exists else None

--- a/pyagent/google_sheets.py
+++ b/pyagent/google_sheets.py
@@ -1,0 +1,21 @@
+from googleapiclient.discovery import build
+from google.oauth2 import service_account
+import os
+
+SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
+
+async def log_request(data: dict) -> str:
+    creds = service_account.Credentials.from_service_account_file(
+        os.environ['GOOGLE_SERVICE_ACCOUNT'], scopes=SCOPES
+    )
+    service = build('sheets', 'v4', credentials=creds)
+    sheet = service.spreadsheets()
+    spreadsheet_id = os.environ['GOOGLE_SHEET_ID']
+    body = {'values': [[data]]}
+    await sheet.values().append(
+        spreadsheetId=spreadsheet_id,
+        range='Requests!A:Z',
+        valueInputOption='RAW',
+        body=body
+    ).execute()
+    return 'Request logged to Google Sheets'

--- a/pyagent/serpapi.py
+++ b/pyagent/serpapi.py
@@ -1,0 +1,29 @@
+from serpapi import GoogleSearch
+import os
+
+async def search_flights(origin: str, destination: str, date: str = None, preferences: str = None):
+    params = {
+        'engine': 'google_flights',
+        'api_key': os.environ['SERPAPI_KEY'],
+        'origin': origin,
+        'destination': destination
+    }
+    if date:
+        params['date'] = date
+    if preferences:
+        params['preferences'] = preferences
+    search = GoogleSearch(params)
+    return search.get_json()
+
+async def search_hotels(location: str, check_in: str = None, check_out: str = None):
+    params = {
+        'engine': 'google_hotels',
+        'api_key': os.environ['SERPAPI_KEY'],
+        'location': location
+    }
+    if check_in:
+        params['checkin'] = check_in
+    if check_out:
+        params['checkout'] = check_out
+    search = GoogleSearch(params)
+    return search.get_json()

--- a/pyagent/slack_app.py
+++ b/pyagent/slack_app.py
@@ -1,0 +1,24 @@
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+from .agent import TravelAgent
+import os
+
+agent = TravelAgent()
+app = App(token=os.environ.get('SLACK_BOT_TOKEN'))
+
+@app.event('message')
+async def handle_message(body, say):
+    event = body.get('event', {})
+    if 'subtype' in event:
+        return
+    user_id = event.get('user')
+    text = event.get('text', '')
+    response = await agent.handle_message(user_id, text)
+    await say(response)
+
+def main():
+    handler = SocketModeHandler(app, os.environ.get('SLACK_APP_TOKEN'))
+    handler.start()
+
+if __name__ == '__main__':
+    main()

--- a/pyagent/tests/test_agent.py
+++ b/pyagent/tests/test_agent.py
@@ -1,0 +1,24 @@
+import pytest
+from pyagent.agent import TravelAgent
+
+class DummyChat:
+    def __init__(self):
+        self.last = None
+    async def send_message(self, text):
+        self.last = text
+        class Resp:
+            text = 'ok'
+        return Resp()
+
+class DummyModel:
+    def __init__(self, *args, **kwargs):
+        pass
+    def start_chat(self, history=None):
+        return DummyChat()
+
+@pytest.mark.asyncio
+async def test_handle_message(monkeypatch):
+    monkeypatch.setattr('pyagent.agent.GenerativeModel', DummyModel)
+    agent = TravelAgent()
+    text = await agent.handle_message('u1', 'hola')
+    assert text == 'ok'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+google-generativeai
+slack_bolt
+firebase-admin
+google-api-python-client
+serpapi


### PR DESCRIPTION
## Summary
- create `pyagent` package with Python version of the agent
- add Firebase, Google Sheets and SerpApi helpers in Python
- Slack integration in Python
- provide test for the Python agent
- document Python usage in README
- add `requirements.txt`

## Testing
- `npm install`
- `npm test`
- `PYTHONPATH=. pytest pyagent/tests`

------
https://chatgpt.com/codex/tasks/task_e_688531775cf88325807eeb0275f4d09f